### PR TITLE
styles: update code-tabs.css for latest sphinx

### DIFF
--- a/sphinx_code_tabs/code-tabs.css
+++ b/sphinx_code_tabs/code-tabs.css
@@ -1,4 +1,4 @@
-.section .code-tabs > ul {
+.code-tabs > ul {
 	margin: 0;
 	padding: 0;
 	display: block;
@@ -9,7 +9,7 @@
   color: #ffffff;
 }
 
-.section .code-tabs > ul li {
+.code-tabs > ul li {
 	margin: 0 5px 0 0;
 	padding: 0px 10px;
 	display: block;
@@ -25,25 +25,25 @@
   transition: 0.3s;
 }
 
-.section .code-tabs > ul li:first-of-type {
+.code-tabs > ul li:first-of-type {
 	margin-left: 2px;
 }
-.section .code-tabs > ul li:last-of-type {
+.code-tabs > ul li:last-of-type {
 	margin-right: 0;
 }
-.section .code-tabs > ul li:hover {
+.code-tabs > ul li:hover {
   background-color: #606060;
 }
-.section .code-tabs > ul li.selected {
+.code-tabs > ul li.selected {
   background-color: #303030;
   border-color: #4070a0;
   border-size: 2px;
 }
-.section .code-tabs > ul li.selected:hover {
+.code-tabs > ul li.selected:hover {
 	background-color: #606060;
 }
 
-.section .code-tabs .code-tab > div {
+.code-tabs .code-tab > div {
 	margin-top: 0;
 }
 


### PR DESCRIPTION
In latest sphinx, class ".section" is changed to tag `<section>`, so the selectors do not apply any longer.