### PR TITLE
Expose metadata to sphinx

### DIFF
--- a/sphinx_code_tabs/__init__.py
+++ b/sphinx_code_tabs/__init__.py
@@ -226,3 +226,8 @@ def setup(app):
     app.add_directive("code-tabs", TabsDirective)
     app.add_directive("code-tab", CodeTabDirective)
     app.connect("builder-inited", add_assets)
+
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+    }


### PR DESCRIPTION
Hello! First of all thank you for the wonderful package!
I enjoy using it for writing my documentation ❤️.

I use sphinx **v5.3.0** with parallel builds (`-j auto`) and it shows the following warning:
```
WARNING: the sphinx_code_tabs extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```

I tinkered through the code and thought that it's pretty safe for parallel reads.
I looked [into the docs](https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata) and then made changes for passing metadata info to the sphinx application.

This PR also contains some style fixes according to common practices (pep8, black, isort), but if you don't want them - I will drop those style-related commits.